### PR TITLE
91 in database option for clustering connected components

### DIFF
--- a/oagdedupe/db/base.py
+++ b/oagdedupe/db/base.py
@@ -451,16 +451,11 @@ class BaseClusterRepository(ABC):
         pass
 
     @abstractmethod
-    def merge_clusters_with_raw_data(self, df_clusters, rl):
+    def merge_clusters_with_raw_data(self, rl):
         """wrapper for get_clusters() and get_clusters_link(); call
         get_clusters_link() instead of get_clusters() if rl != ""
 
         in sql, also saves df_clusters to `clusters` table
-
-        Parameters
-        ----------
-        `df_clusters` is the output of get_connected_components() in
-        oagdedupe.cluster
         """
         pass
 

--- a/oagdedupe/db/postgres/Dockerfile
+++ b/oagdedupe/db/postgres/Dockerfile
@@ -1,8 +1,8 @@
 FROM postgres:14
 
 RUN apt-get update
-RUN apt-get -y install python3 postgresql-plpython3-14 git make gcc 
-RUN apt-get -y install postgresql-server-dev-14
+RUN apt-get -y install python3 python3-pip postgresql-plpython3-14 git make gcc 
+RUN apt-get -y install postgresql-server-dev-14 postgresql-14-pgrouting
 
 RUN git clone https://github.com/eulerto/pg_similarity.git \
  && cd pg_similarity \

--- a/oagdedupe/db/postgres/funcs.py
+++ b/oagdedupe/db/postgres/funcs.py
@@ -14,7 +14,7 @@ def create_functions(settings: Settings):
         CREATE EXTENSION IF NOT EXISTS pg_trgm;
         CREATE EXTENSION IF NOT EXISTS plpython3u;
         CREATE EXTENSION IF NOT EXISTS pg_similarity;
-        CREATE EXTENSION IF NOT EXISTS pgrouting;
+        CREATE EXTENSION IF NOT EXISTS pgrouting CASCADE;
         CREATE OR REPLACE LANGUAGE pg_trgm;
         CREATE OR REPLACE LANGUAGE plpython3u;
         CREATE OR REPLACE LANGUAGE pg_similarity;

--- a/oagdedupe/db/postgres/funcs.py
+++ b/oagdedupe/db/postgres/funcs.py
@@ -14,6 +14,7 @@ def create_functions(settings: Settings):
         CREATE EXTENSION IF NOT EXISTS pg_trgm;
         CREATE EXTENSION IF NOT EXISTS plpython3u;
         CREATE EXTENSION IF NOT EXISTS pg_similarity;
+        CREATE EXTENSION IF NOT EXISTS pgrouting;
         CREATE OR REPLACE LANGUAGE pg_trgm;
         CREATE OR REPLACE LANGUAGE plpython3u;
         CREATE OR REPLACE LANGUAGE pg_similarity;

--- a/oagdedupe/db/postgres/orm.py
+++ b/oagdedupe/db/postgres/orm.py
@@ -166,9 +166,7 @@ class ClusterRepository(BaseClusterRepository, Tables):
                 dflist.append(pd.read_sql(q.statement, q.session.bind))
             return dflist
 
-    def merge_clusters_with_raw_data(self, df_clusters, rl):
-
-        self.bulk_insert(df=df_clusters, to_table=self.Clusters)
+    def merge_clusters_with_raw_data(self, rl):
 
         if rl == "":
             return self.get_clusters()


### PR DESCRIPTION
Purpose of this PR is to abstract out the clustering logic and move the "get_connected_components" function into repository. For the postgres repository, the "get_connected_components" logic can be solved using the [pgrouting library](https://github.com/pgRouting/pgrouting). This library extends postgres with network analysis tools.